### PR TITLE
"xmlrpc.php" is now blocked really fast/efficiently

### DIFF
--- a/wordpress/deploy.sh
+++ b/wordpress/deploy.sh
@@ -311,6 +311,8 @@ sed -i "s/# DB_HOST='localhost'/DB_HOST='localhost'/g" .env
 # Create a generic .htaccess file for permalinks (for convenience...user can FTP up a real one if needed)
 # ---------------------------------------------
 echo "
+ErrorDocument 403 default
+
 #### Password protect this directory (excl. PVTL office, Neon, Carbon)
 # AuthType Basic
 # AuthName 'restricted area'
@@ -326,9 +328,7 @@ echo "
 
 #### Block access to xml-rpc.php
 #### It's usually how malicious actors brute force logins
-<Files xmlrpc.php>
- deny from all
-</Files>
+RewriteRule ^(.+\/)?xmlrpc.php$ - [F,L]
 
 #### Custom rules
 <IfModule mod_rewrite.c>


### PR DESCRIPTION
I tried using the current xmlrpc.php blocking snippet for the .htaccess file on Affinity, but when I accessed that URL it displayed a "page not found" WP screen. The page load also took 2-4 seconds.

I've replaced it with the attached changes and now the 403 Access Denied responses are lightning fast.

Can we adopt these changes on newer WP sites?

We could possibly extend this to blocking wp-cron.php (assuming it's run via the CLI) and any other URL's as required.